### PR TITLE
umap-agent: adjust init script to properly detect bridge VLANs

### DIFF
--- a/umapd/files/umapd.agent.init
+++ b/umapd/files/umapd.agent.init
@@ -6,6 +6,21 @@ USE_PROCD=1
 NAME=umap-agent
 PROG=/usr/sbin/umapd
 
+is_bridge() {
+	local ifname=$1
+
+	while [ -e "/sys/class/net/${ifname}" ]; do
+		[ -e "/sys/class/net/${ifname}/bridge" ] && return 0
+
+		ifname='*'
+		for lower in "/sys/class/net/${ifname}/lower_"*; do
+			ifname=${lower##*/lower_}
+		done
+	done
+
+	return 1
+}
+
 start_service() {
 	local interfaces=$(uci -q get umapd.@agent[0].interface)
 	local verbosity=$(uci -q get umapd.@agent[0].verbosity)
@@ -26,7 +41,7 @@ start_service() {
 	done
 
 	for bridge in $bridges; do
-		[ -e "/sys/class/net/$bridge/bridge" ] || continue
+		is_bridge "$bridge" || continue
 		bridgedevs="${bridgedevs:+$bridgedevs }$bridge"
 	done
 


### PR DESCRIPTION
Resolve the given interface change in order to check whether any of the lower interfaces is a bridge, not just the given interface itself.